### PR TITLE
updating first entry

### DIFF
--- a/docs/leaderboards-format.md
+++ b/docs/leaderboards-format.md
@@ -25,7 +25,7 @@ Note: The first 2 entries in each array appear to always be empty.
 
 | Offset | Type | Notes |
 | ------ | ---- | ----- |
-| 0000010 | uint64 LE | Steam / PSN IDs |
+| 0000010 | uint64 LE | Unique ID for the entry |
 | 07A1208 | 33 bytes. Fixed width string buffer. utf-8 | Usernames |
 | 2719C48 | 2 bytes | Unknown
 | 29020D0 | 4 bytes | Unknown


### PR DESCRIPTION
Discussed in the daily challenge. Conversation starts here: https://discord.com/channels/743572260408787016/744886841462751352/785539212308250636

The first entry does not appear to be the steam/psn id but rather some other type of unique id. it's possible that the steam/psnid here is encoded in some way but the frequent collisions of ids with different players leads me to believe that it's something else